### PR TITLE
Add encrypted password storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
     />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"></script>
   </head>
 
   <body>
@@ -26,6 +27,9 @@
         />
         <button id="copyButton" title="Copy to Clipboard">
           <i class="far fa-copy"></i>
+        </button>
+        <button id="saveButton" title="Save Password">
+          <i class="far fa-save"></i>
         </button>
       </div>
       
@@ -81,10 +85,21 @@
         
       </div>
 
-      <button id="generateButton">Generate Password</button>
-      <div id="error-message" class="error-message"></div>
-    </div>
+        <button id="generateButton">Generate Password</button>
+        <button id="viewSavedButton">Saved Passwords</button>
+        <div id="error-message" class="error-message"></div>
+      </div>
 
-    <script src="script.js"></script>
-  </body>
-</html>
+      <div id="savedPasswordsContainer" class="saved-passwords hidden"></div>
+      <div id="authOverlay" class="auth-overlay hidden">
+        <div class="auth-dialog">
+          <div id="authMessage" class="auth-message"></div>
+          <input type="password" id="authInput" placeholder="Master Password" />
+          <input type="password" id="authConfirm" placeholder="Confirm Password" class="hidden" />
+          <button id="authSubmit">Submit</button>
+        </div>
+      </div>
+
+      <script src="script.js"></script>
+    </body>
+  </html>

--- a/style.css
+++ b/style.css
@@ -109,6 +109,25 @@ h1 {
   box-shadow: 0 0 8px var(--primary-hover);
 }
 
+#saveButton {
+  padding: 5px 12px;
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+  border: none;
+  border-left: 3px solid var(--bg-color);
+  border-right: 4px solid var(--bg-color);
+  border-radius: 2px 50px 2px 30px;
+  cursor: pointer;
+  font-size: 1.1rem;
+  transition: background-color 0.5s ease;
+  margin-left: 5px;
+}
+
+#saveButton:hover {
+  background-color: var(--primary-hover);
+  box-shadow: 0 0 8px var(--primary-hover);
+}
+
 .copy-message {
   color: var(--success-color);
   font-size: 0.7em;
@@ -300,8 +319,113 @@ input[type="checkbox"]:checked::after {
   transform: scale(0.98);
 }
 
+#viewSavedButton {
+  background-color: var(--primary-color);
+  color: #1a1b1f;
+  border: 1px solid var(--border-color);
+  padding: 10px;
+  border-radius: 100px 1px 100px 1px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  width: 85%;
+  margin-top: 5px;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+#viewSavedButton:hover {
+  background-color: var(--primary-hover);
+  box-shadow: 0 0 8px var(--primary-hover);
+}
+
+#viewSavedButton:active {
+  transform: scale(0.98);
+}
+
 @media (max-width: 400px) {
   .container {
     padding: 20px;
   }
+}
+
+.saved-passwords {
+  margin-top: 15px;
+  max-height: 200px;
+  overflow-y: auto;
+  text-align: left;
+}
+
+.saved-entry {
+  background-color: var(--input-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 5px 10px;
+  margin-bottom: 5px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.saved-entry button {
+  background-color: var(--primary-color);
+  border: none;
+  color: var(--bg-color);
+  padding: 3px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.saved-entry button:hover {
+  background-color: var(--primary-hover);
+}
+
+.auth-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.auth-dialog {
+  background-color: var(--container-bg);
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+  width: 90%;
+  max-width: 300px;
+}
+
+.auth-dialog input {
+  width: 100%;
+  padding: 5px;
+  margin: 8px 0;
+  border: 1px solid var(--border-color);
+  background-color: var(--input-bg);
+  color: var(--text-color);
+  border-radius: 6px;
+}
+
+.auth-dialog button {
+  background-color: var(--primary-color);
+  color: var(--bg-color);
+  border: none;
+  padding: 8px 15px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.auth-dialog button:hover {
+  background-color: var(--primary-hover);
+}
+
+.hidden {
+  display: none;
 }


### PR DESCRIPTION
## Summary
- add CryptoJS library to enable AES encryption
- add Save button and Saved Passwords panel
- prompt user for a master password on first save/view
- store encrypted passwords in localStorage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6879b80c5670832b91dbad3ed46e257d