### PR TITLE
feat: add encrypted password store

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ PassLock is a desktop application for generating secure passwords with customiza
 * Displays a real-time password strength indicator.
 * Provides a one-click copy-to-clipboard button for the generated password.
 * Runs as a tray application for easy access.
+* Stores passwords securely with AES-256-GCM encryption.
 
 ## Technologies Used
 
@@ -49,6 +50,26 @@ PassLock is a desktop application for generating secure passwords with customiza
     ```bash
     npm start
     ```
+
+### Password Storage
+
+PassLock can persist passwords to an encrypted store. Set the `PASSLOCK_MASTER_KEY`
+environment variable to a secret string before running the app. The renderer can
+interact with the store through the `passwordStore` API exposed on `window`:
+
+```javascript
+// Add a password entry
+window.passwordStore.add({ service: 'Example', username: 'alice', password: 'secret' });
+
+// Get all stored passwords
+window.passwordStore.getAll().then(entries => console.log(entries));
+
+// Remove by id
+window.passwordStore.remove(id);
+```
+
+The encrypted data file is saved in the Electron `userData` directory
+(`app.getPath('userData')`).
 
 ### Building for Distribution
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "files": [
       "src/app/main.js",
       "src/app/tray.js",
+      "src/app/preload.js",
+      "src/app/passwordStore.js",
       "src/renderer/index.html",
       "src/renderer/script.js",
       "src/renderer/style.css",

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -1,7 +1,8 @@
 // main.js
-const { app, BrowserWindow } = require('electron');
-const path  = require('path');
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
 const createTray = require('./tray.js');
+const passwordStore = require('./passwordStore.js');
 
 let mainWindow;
 let tray;
@@ -36,6 +37,7 @@ function createWindow () {
     backgroundColor: '#00000000',
     roundedCorners:true,
     webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
       nodeIntegration: false,
       contextIsolation: true,
     },
@@ -53,8 +55,21 @@ function createWindow () {
 }
 
 app.whenReady().then(() => {
+  passwordStore.initStore();
   createWindow();
   tray = createTray(mainWindow);
+});
+
+ipcMain.handle('password-add', (event, entry) => {
+  return passwordStore.addPassword(entry);
+});
+
+ipcMain.handle('password-get-all', () => {
+  return passwordStore.getPasswords();
+});
+
+ipcMain.handle('password-remove', (event, id) => {
+  return passwordStore.removePassword(id);
 });
 
 app.on('before-quit', () => (isQuitting = true));

--- a/src/app/passwordStore.js
+++ b/src/app/passwordStore.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { app } = require('electron');
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH = 32;
+const IV_LENGTH = 16;
+const TAG_LENGTH = 16;
+const SALT_LENGTH = 16;
+const ITERATIONS = 100000;
+
+const STORE_FILE = path.join(app.getPath('userData'), 'passwords.enc');
+const MASTER_PASSWORD = process.env.PASSLOCK_MASTER_KEY || 'change_this_key';
+
+function deriveKey(password, salt) {
+  return crypto.pbkdf2Sync(password, salt, ITERATIONS, KEY_LENGTH, 'sha256');
+}
+
+function encrypt(data) {
+  const salt = crypto.randomBytes(SALT_LENGTH);
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const key = deriveKey(MASTER_PASSWORD, salt);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(JSON.stringify(data), 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([salt, iv, tag, encrypted]).toString('base64');
+}
+
+function decrypt(encoded) {
+  const buffer = Buffer.from(encoded, 'base64');
+  const salt = buffer.slice(0, SALT_LENGTH);
+  const iv = buffer.slice(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+  const tag = buffer.slice(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
+  const text = buffer.slice(SALT_LENGTH + IV_LENGTH + TAG_LENGTH);
+  const key = deriveKey(MASTER_PASSWORD, salt);
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(text), decipher.final()]);
+  return JSON.parse(decrypted.toString('utf8'));
+}
+
+function readStore() {
+  if (!fs.existsSync(STORE_FILE)) {
+    return [];
+  }
+  const enc = fs.readFileSync(STORE_FILE, 'utf8');
+  return decrypt(enc);
+}
+
+function writeStore(entries) {
+  const enc = encrypt(entries);
+  fs.writeFileSync(STORE_FILE, enc, { mode: 0o600 });
+}
+
+function initStore() {
+  if (!fs.existsSync(STORE_FILE)) {
+    writeStore([]);
+  }
+}
+
+function getPasswords() {
+  return readStore();
+}
+
+function addPassword(entry) {
+  const entries = readStore();
+  const newEntry = { id: crypto.randomUUID(), ...entry, createdAt: new Date().toISOString() };
+  entries.push(newEntry);
+  writeStore(entries);
+  return newEntry;
+}
+
+function removePassword(id) {
+  const entries = readStore();
+  const filtered = entries.filter(e => e.id !== id);
+  writeStore(filtered);
+  return filtered;
+}
+
+module.exports = { initStore, getPasswords, addPassword, removePassword };

--- a/src/app/preload.js
+++ b/src/app/preload.js
@@ -1,0 +1,7 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('passwordStore', {
+  add: (entry) => ipcRenderer.invoke('password-add', entry),
+  getAll: () => ipcRenderer.invoke('password-get-all'),
+  remove: (id) => ipcRenderer.invoke('password-remove', id)
+});


### PR DESCRIPTION
## Summary
- add passwordStore module using AES-256-GCM encryption
- expose password store APIs to renderer via preload and IPC
- document password storage usage and include new files in build configuration

## Testing
- `npm test` *(fails: Missing script "test" )*


------
https://chatgpt.com/codex/tasks/task_e_68b404fcfba8832b98241dde2093baa5