### PR TITLE
feat: add master password protection

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,9 @@
           <button class="btn btn-primary" id="addPasswordBtn">
             <i class="fas fa-plus"></i> Add Password
           </button>
+          <button class="btn btn-secondary" id="lockVaultBtn">
+            <i class="fas fa-lock"></i> Lock Vault
+          </button>
         </div>
 
         <div id="passwordList" class="password-list">
@@ -127,6 +130,30 @@
         </div>
       </div>
     </main>
+  </div>
+
+  <!-- Master Password Modal -->
+  <div id="masterPasswordModal" class="modal">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2 id="masterPasswordModalTitle">Set Master Password</h2>
+        <button class="modal-close" data-modal="masterPasswordModal">&times;</button>
+      </div>
+      <form id="masterPasswordForm">
+        <div class="form-group">
+          <label for="masterPasswordInput">Master Password</label>
+          <input type="password" id="masterPasswordInput" required>
+        </div>
+        <div class="form-group" id="confirmMasterPasswordGroup">
+          <label for="confirmMasterPassword">Confirm Password</label>
+          <input type="password" id="confirmMasterPassword" required>
+        </div>
+        <div class="form-actions">
+          <button type="button" class="btn btn-secondary modal-cancel" data-modal="masterPasswordModal">Cancel</button>
+          <button type="submit" class="btn btn-primary" id="masterPasswordSubmit">Set Password</button>
+        </div>
+      </form>
+    </div>
   </div>
 
   <!-- Save Password Modal -->


### PR DESCRIPTION
## Summary
- add modal to set or enter a master password
- require master password to access the vault and allow relocking

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b45a84dbfc832babcc1686a3e4f91d