### PR TITLE
feat: add master password and vault locking

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,15 +106,18 @@
 
       <!-- Vault Tab -->
       <div id="vault" class="tab-content">
-        <div class="vault-header">
-          <div class="search-container">
-            <input type="text" class="search-input" id="searchInput" placeholder="Search passwords...">
-            <i class="fas fa-search search-icon"></i>
+          <div class="vault-header">
+            <div class="search-container">
+              <input type="text" class="search-input" id="searchInput" placeholder="Search passwords...">
+              <i class="fas fa-search search-icon"></i>
+            </div>
+            <button class="btn btn-primary" id="addPasswordBtn">
+              <i class="fas fa-plus"></i> Add Password
+            </button>
+            <button class="btn btn-secondary" id="lockVaultBtn">
+              <i class="fas fa-lock"></i> Lock
+            </button>
           </div>
-          <button class="btn btn-primary" id="addPasswordBtn">
-            <i class="fas fa-plus"></i> Add Password
-          </button>
-        </div>
 
         <div id="passwordList" class="password-list">
           <!-- Password items will be dynamically inserted here -->
@@ -130,12 +133,12 @@
   </div>
 
   <!-- Save Password Modal -->
-  <div id="saveModal" class="modal">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h2>Save Password</h2>
-        <button class="modal-close" data-modal="saveModal">&times;</button>
-      </div>
+    <div id="saveModal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Save Password</h2>
+          <button class="modal-close" data-modal="saveModal">&times;</button>
+        </div>
       <form id="saveForm">
         <div class="form-group">
           <label for="siteName">Site/Service Name</label>
@@ -158,8 +161,52 @@
           <button type="submit" class="btn btn-primary">Save</button>
         </div>
       </form>
+      </div>
     </div>
-  </div>
+
+    <!-- Master Password Setup Modal -->
+    <div id="setupMasterModal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Set Master Password</h2>
+          <button class="modal-close" data-modal="setupMasterModal">&times;</button>
+        </div>
+        <form id="setupMasterForm">
+          <div class="form-group">
+            <label for="masterPassword">Master Password</label>
+            <input type="password" id="masterPassword" required>
+          </div>
+          <div class="form-group">
+            <label for="masterPasswordConfirm">Confirm Password</label>
+            <input type="password" id="masterPasswordConfirm" required>
+          </div>
+          <div class="form-actions">
+            <button type="button" class="btn btn-secondary modal-cancel" data-modal="setupMasterModal">Cancel</button>
+            <button type="submit" class="btn btn-primary">Set Password</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- Master Password Unlock Modal -->
+    <div id="unlockMasterModal" class="modal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Unlock Vault</h2>
+          <button class="modal-close" data-modal="unlockMasterModal">&times;</button>
+        </div>
+        <form id="unlockMasterForm">
+          <div class="form-group">
+            <label for="masterPasswordInput">Master Password</label>
+            <input type="password" id="masterPasswordInput" required>
+          </div>
+          <div class="form-actions">
+            <button type="button" class="btn btn-secondary modal-cancel" data-modal="unlockMasterModal">Cancel</button>
+            <button type="submit" class="btn btn-primary">Unlock</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
   <!-- Toast Notification -->
   <div id="toast" class="toast">


### PR DESCRIPTION
## Summary
- add lock button and modals for master password setup and unlocking
- store hashed master password and lock state in script
- gate vault access behind master password and allow locking

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b45a84dbfc832babcc1686a3e4f91d