### PR TITLE
Streamline mobile generator layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,13 +25,13 @@
           </div>
           <div class="brand-copy">
             <span class="brand-name">PassLock</span>
-            <span class="brand-tagline">Privacy-first credentials</span>
+            <span class="brand-tagline">Instant password generator</span>
           </div>
         </div>
         <div class="header-actions">
           <span class="status-pill">
             <i class="fa-solid fa-lock" aria-hidden="true"></i>
-            Local-only generation
+            Offline ready
           </span>
         </div>
       </header>
@@ -40,20 +40,15 @@
         <section class="panel generator-panel">
           <div class="panel-header">
             <span class="eyebrow">Password generator</span>
-            <h1>Craft privacy-grade passwords</h1>
-            <p>
-              Generate high-entropy credentials tailored to your policy. When the
-              vault launches, you'll be able to save every secret in one
-              encrypted place.
-            </p>
+            <h1>Quick, strong passwords</h1>
           </div>
 
-          <div class="password-surface">
+          <div class="password-area">
             <div class="password-display-container">
               <input
                 type="text"
                 id="passwordDisplay"
-                placeholder="Tap Generate to produce a password"
+                placeholder="Tap Generate to create a password"
                 readonly
                 aria-label="Generated password"
               />
@@ -76,89 +71,57 @@
             </div>
           </div>
 
-          <div class="options">
-            <div class="option-section">
-              <div class="section-header">
-                <span class="section-title">Length &amp; policy</span>
-                <span class="section-subtitle"
-                  >Define the baseline rules for your password.</span
-                >
-              </div>
-
-              <div class="range-control">
-                <div class="range-label">
-                  <span>Password length</span>
-                  <span id="lengthValue" class="pill">16</span>
-                </div>
-                <input
-                  type="range"
-                  id="lengthSlider"
-                  min="4"
-                  max="28"
-                  value="16"
-                  aria-labelledby="lengthValue"
-                />
-                <div class="range-scale" aria-hidden="true">
-                  <span>4</span>
-                  <span>28</span>
-                </div>
-              </div>
-
-              <div class="input-field">
-                <label for="excludeChars">Exclude characters</label>
-                <div class="input-wrapper">
-                  <i class="fa-solid fa-slash" aria-hidden="true"></i>
-                  <input
-                    type="text"
-                    id="excludeChars"
-                    placeholder="e.g. 0O1Il|${}" />
-                </div>
-                <p class="field-hint">
-                  Characters in this list will never appear in generated
-                  passwords.
-                </p>
-              </div>
+          <div class="primary-controls">
+            <div class="range-control">
+              <label class="range-label" for="lengthSlider">
+                <span>Length</span>
+                <span id="lengthValue" class="pill">18</span>
+              </label>
+              <input
+                type="range"
+                id="lengthSlider"
+                min="4"
+                max="28"
+                value="18"
+              />
             </div>
+            <button id="generateButton" type="button" class="btn btn--primary">
+              <i class="fa-solid fa-bolt" aria-hidden="true"></i>
+              Generate
+            </button>
+          </div>
 
-            <div class="option-section">
-              <div class="section-header">
-                <span class="section-title">Character sets</span>
-                <span class="section-subtitle"
-                  >Select the building blocks for each password.</span
-                >
-              </div>
-              <div class="toggle-grid">
-                <label class="toggle">
+          <div class="option-groups">
+            <div class="option-group">
+              <span class="group-title">Characters</span>
+              <div class="option-grid">
+                <label class="check-option">
                   <input type="checkbox" id="includeUppercase" checked />
-                  <span class="toggle-control" aria-hidden="true"></span>
-                  <span class="toggle-label">
+                  <span>
                     <strong>Uppercase</strong>
                     <small>A–Z</small>
                   </span>
                 </label>
 
-                <label class="toggle">
+                <label class="check-option">
                   <input type="checkbox" id="includeLowercase" checked />
-                  <span class="toggle-control" aria-hidden="true"></span>
-                  <span class="toggle-label">
+                  <span>
                     <strong>Lowercase</strong>
                     <small>a–z</small>
                   </span>
                 </label>
 
-                <label class="toggle">
+                <label class="check-option">
                   <input type="checkbox" id="includeNumbers" checked />
-                  <span class="toggle-control" aria-hidden="true"></span>
-                  <span class="toggle-label">
+                  <span>
                     <strong>Numbers</strong>
                     <small>0–9</small>
                   </span>
                 </label>
 
-                <label class="toggle">
-                  <input type="checkbox" id="includeSymbols" />
-                  <span class="toggle-control" aria-hidden="true"></span>
-                  <span class="toggle-label">
+                <label class="check-option">
+                  <input type="checkbox" id="includeSymbols" checked />
+                  <span>
                     <strong>Symbols</strong>
                     <small>!@#$%^</small>
                   </span>
@@ -166,128 +129,42 @@
               </div>
             </div>
 
-            <div class="option-section">
-              <div class="section-header">
-                <span class="section-title">Policy guards</span>
-                <span class="section-subtitle"
-                  >Keep output compliant with your security requirements.</span
-                >
-              </div>
-              <div class="toggle-grid">
-                <label class="toggle">
-                  <input type="checkbox" id="requireAllTypes" />
-                  <span class="toggle-control" aria-hidden="true"></span>
-                  <span class="toggle-label">
-                    <strong>Require all selected sets</strong>
-                    <small>Guarantees variety in every password.</small>
+            <div class="option-group">
+              <span class="group-title">Extras</span>
+              <div class="option-grid option-grid--compact">
+                <label class="check-option">
+                  <input type="checkbox" id="requireAllTypes" checked />
+                  <span>
+                    <strong>Use every set</strong>
+                    <small>Guarantee variety</small>
                   </span>
                 </label>
 
-                <label class="toggle">
-                  <input type="checkbox" id="avoidAmbiguous" />
-                  <span class="toggle-control" aria-hidden="true"></span>
-                  <span class="toggle-label">
-                    <strong>Avoid ambiguous</strong>
-                    <small>Skip look-alike characters such as 0O1Il|.</small>
+                <label class="check-option">
+                  <input type="checkbox" id="avoidAmbiguous" checked />
+                  <span>
+                    <strong>Avoid look-alikes</strong>
+                    <small>Skip 0O1Il|</small>
                   </span>
                 </label>
               </div>
             </div>
-          </div>
 
-          <div class="action-row">
-            <button id="generateButton" type="button" class="btn btn--primary">
-              <i class="fa-solid fa-bolt" aria-hidden="true"></i>
-              Generate password
-            </button>
-            <button type="button" class="btn btn--ghost" disabled>
-              <i class="fa-solid fa-floppy-disk" aria-hidden="true"></i>
-              Save to vault (coming soon)
-            </button>
+            <div class="input-field">
+              <label for="excludeChars">Exclude characters</label>
+              <div class="input-wrapper">
+                <i class="fa-solid fa-slash" aria-hidden="true"></i>
+                <input
+                  type="text"
+                  id="excludeChars"
+                  placeholder="Type characters to skip"
+                />
+              </div>
+            </div>
           </div>
 
           <div id="error-message" class="error-message" role="alert"></div>
         </section>
-
-        <aside class="panel vault-panel">
-          <div class="panel-header">
-            <span class="eyebrow">Vault vision</span>
-            <h2>Designed for zero-knowledge storage</h2>
-            <p>
-              PassLock's next milestone introduces an encrypted vault to safely
-              catalogue credentials without leaking metadata.
-            </p>
-          </div>
-
-          <ul class="vault-highlights">
-            <li>
-              <i class="fa-solid fa-user-lock" aria-hidden="true"></i>
-              <span>Keys that never leave your device.</span>
-            </li>
-            <li>
-              <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
-              <span>Fast search across tags, services, and teams.</span>
-            </li>
-            <li>
-              <i class="fa-solid fa-sitemap" aria-hidden="true"></i>
-              <span>Audit trails for shared credentials and rotation.</span>
-            </li>
-          </ul>
-
-          <div class="vault-wireframe" aria-hidden="true">
-            <div class="vault-wireframe-header">
-              <span class="col-service">Service</span>
-              <span class="col-updated">Updated</span>
-              <span class="col-strength">Strength</span>
-            </div>
-            <div class="vault-item">
-              <div class="vault-service">
-                <i class="fa-solid fa-globe"></i>
-                <div>
-                  <span class="title">console.passlock.dev</span>
-                  <span class="meta">Workspace • Admin</span>
-                </div>
-              </div>
-              <span class="vault-updated">moments ago</span>
-              <span class="vault-strength strong">Strong</span>
-            </div>
-            <div class="vault-item">
-              <div class="vault-service">
-                <i class="fa-solid fa-cloud"></i>
-                <div>
-                  <span class="title">infra.cluster</span>
-                  <span class="meta">Production • Shared</span>
-                </div>
-              </div>
-              <span class="vault-updated">yesterday</span>
-              <span class="vault-strength medium">Medium</span>
-            </div>
-            <div class="vault-item">
-              <div class="vault-service">
-                <i class="fa-solid fa-mobile-screen-button"></i>
-                <div>
-                  <span class="title">mobile-app</span>
-                  <span class="meta">Personal • Device</span>
-                </div>
-              </div>
-              <span class="vault-updated">12 days ago</span>
-              <span class="vault-strength weak">Weak</span>
-            </div>
-          </div>
-
-          <div class="vault-empty">
-            <i class="fa-solid fa-inbox" aria-hidden="true"></i>
-            <h3>Vault inbox ready</h3>
-            <p>
-              Saved passwords will land here with filtering, tagging, and quick
-              actions. Start planning naming conventions and tags to stay
-              organized from day one.
-            </p>
-            <button type="button" class="btn btn--secondary" disabled>
-              Outline vault categories
-            </button>
-          </div>
-        </aside>
       </main>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -19,6 +19,7 @@
   --shadow-card: 0 18px 40px rgba(2, 6, 23, 0.45);
   --font-sans: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --layout-page-padding: clamp(18px, 5vw, 32px);
 }
 
 * {
@@ -38,12 +39,25 @@ body {
   color: var(--color-text-primary);
   font-family: var(--font-sans);
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
-  padding: 32px;
+  padding: var(--layout-page-padding);
+  padding-top: var(--layout-page-padding);
+  padding-bottom: var(--layout-page-padding);
   position: relative;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Extend body padding to respect device safe areas when available */
+body {
+  padding-top: calc(var(--layout-page-padding) + constant(safe-area-inset-top));
+  padding-bottom: calc(var(--layout-page-padding) + constant(safe-area-inset-bottom));
+  padding-top: calc(var(--layout-page-padding) + env(safe-area-inset-top));
+  padding-bottom: calc(var(--layout-page-padding) + env(safe-area-inset-bottom));
 }
 
 button,
@@ -54,6 +68,12 @@ select {
   -webkit-app-region: no-drag;
   font: inherit;
   color: inherit;
+}
+
+@media (pointer: coarse) {
+  body {
+    -webkit-app-region: initial;
+  }
 }
 
 .background-glow {
@@ -80,18 +100,19 @@ select {
 .app-container {
   position: relative;
   z-index: 1;
-  width: min(100%, 1100px);
+  width: min(100%, 760px);
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 20px;
 }
 
 .app-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 18px 24px;
-  border-radius: 24px;
+  padding: 14px 20px;
+  border-radius: 20px;
   background: rgba(15, 23, 42, 0.72);
   border: 1px solid var(--color-border);
   backdrop-filter: blur(16px);
@@ -101,12 +122,12 @@ select {
 .brand {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
 }
 
 .brand-mark {
-  width: 48px;
-  height: 48px;
+  width: 44px;
+  height: 44px;
   display: grid;
   place-items: center;
   border-radius: 16px;
@@ -127,7 +148,7 @@ select {
 }
 
 .brand-tagline {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: var(--color-text-muted);
 }
 
@@ -141,8 +162,8 @@ select {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 0.85rem;
-  padding: 8px 14px;
+  font-size: 0.8rem;
+  padding: 6px 12px;
   border-radius: 999px;
   background: rgba(56, 189, 248, 0.1);
   border: 1px solid rgba(56, 189, 248, 0.25);
@@ -150,16 +171,15 @@ select {
 }
 
 .app-main {
-  display: grid;
-  gap: 28px;
-  grid-template-columns: minmax(0, 1.7fr) minmax(0, 1fr);
-  align-items: start;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .panel {
   background: var(--color-surface);
-  border-radius: 32px;
-  padding: 32px;
+  border-radius: 24px;
+  padding: 24px;
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-card);
   backdrop-filter: blur(24px);
@@ -169,7 +189,7 @@ select {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  margin-bottom: 24px;
+  margin-bottom: 16px;
 }
 
 .panel-header h1,
@@ -191,19 +211,19 @@ select {
   color: var(--color-text-muted);
 }
 
-.password-surface {
+.password-area {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 14px;
 }
 
 .password-display-container {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   border: 1px solid var(--color-border-strong);
-  border-radius: 22px;
-  padding: 14px 16px;
+  border-radius: 18px;
+  padding: 12px 14px;
   background: linear-gradient(120deg, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.65));
   position: relative;
 }
@@ -232,9 +252,9 @@ select {
   align-items: center;
   gap: 8px;
   border: none;
-  border-radius: 16px;
-  height: 44px;
-  padding: 0 18px;
+  border-radius: 14px;
+  height: 40px;
+  padding: 0 16px;
   font-weight: 600;
   background: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
   color: #04111e;
@@ -254,12 +274,12 @@ select {
 .copy-message {
   position: absolute;
   right: 16px;
-  top: -38px;
+  top: -32px;
   background: rgba(56, 189, 248, 0.9);
   color: #04111e;
-  padding: 6px 14px;
+  padding: 6px 12px;
   border-radius: 999px;
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   letter-spacing: 0.04em;
   opacity: 0;
   transform: translateY(-4px);
@@ -279,7 +299,7 @@ select {
 
 .strength-wrapper {
   display: flex;
-  gap: 16px;
+  gap: 12px;
   align-items: center;
 }
 
@@ -302,56 +322,122 @@ select {
 .strength-text {
   font-size: 0.85rem;
   color: var(--color-text-muted);
-  min-width: 150px;
+  min-width: 120px;
 }
 
-.options {
+.primary-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: end;
+  margin-top: 8px;
+}
+
+.primary-controls #generateButton {
+  min-width: 140px;
+  justify-content: center;
+  align-self: stretch;
+}
+
+.option-groups {
   display: flex;
   flex-direction: column;
-  gap: 28px;
-  margin-top: 10px;
+  gap: 16px;
+  margin-top: 12px;
 }
 
-.option-section {
+.option-group {
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 10px;
 }
 
-.section-header {
+.group-title {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.option-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.option-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.check-option {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid var(--color-border);
+  background: rgba(15, 23, 42, 0.6);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.check-option:hover {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(56, 189, 248, 0.08);
+}
+
+.check-option input {
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+  flex-shrink: 0;
+  accent-color: var(--color-accent);
+}
+
+.check-option span {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
-.section-title {
+.check-option strong {
+  font-size: 0.9rem;
   font-weight: 600;
 }
 
-.section-subtitle {
-  font-size: 0.82rem;
+.check-option small {
+  font-size: 0.75rem;
   color: var(--color-text-muted);
+}
+
+.check-option input:focus-visible + span {
+  outline: 2px solid rgba(56, 189, 248, 0.6);
+  border-radius: 8px;
+  outline-offset: 2px;
 }
 
 .range-control {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
 }
 
 .range-label {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
 .pill {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 42px;
-  padding: 4px 12px;
+  min-width: 36px;
+  padding: 4px 10px;
   border-radius: 999px;
   background: var(--color-accent-soft);
   color: var(--color-accent);
@@ -408,7 +494,7 @@ input[type="range"]:hover::-moz-range-thumb {
 .input-field {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .input-field label {
@@ -419,7 +505,7 @@ input[type="range"]:hover::-moz-range-thumb {
   display: flex;
   align-items: center;
   gap: 10px;
-  border-radius: 16px;
+  border-radius: 14px;
   border: 1px solid var(--color-border);
   background: rgba(15, 23, 42, 0.6);
   padding: 0 14px;
@@ -451,97 +537,15 @@ input[type="range"]:hover::-moz-range-thumb {
   color: var(--color-text-muted);
 }
 
-.toggle-grid {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.toggle {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 16px;
-  border-radius: 18px;
-  border: 1px solid var(--color-border);
-  background: var(--color-surface-elevated);
-  cursor: pointer;
-  transition: border-color 0.2s ease, transform 0.2s ease;
-}
-
-.toggle:hover {
-  border-color: rgba(56, 189, 248, 0.45);
-  transform: translateY(-1px);
-}
-
-.toggle input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.toggle-control {
-  width: 46px;
-  height: 26px;
-  border-radius: 999px;
-  background: rgba(148, 163, 184, 0.35);
-  position: relative;
-  flex-shrink: 0;
-  transition: background 0.25s ease;
-}
-
-.toggle-control::after {
-  content: "";
-  position: absolute;
-  top: 3px;
-  left: 4px;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: #fff;
-  transition: transform 0.25s ease;
-}
-
-.toggle input:checked + .toggle-control {
-  background: rgba(56, 189, 248, 0.6);
-}
-
-.toggle input:checked + .toggle-control::after {
-  transform: translateX(18px);
-}
-
-.toggle-label {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-
-.toggle-label strong {
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.toggle-label small {
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
-}
-
-.action-row {
-  margin-top: 24px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-}
 
 .btn {
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  border-radius: 999px;
-  padding: 14px 24px;
+  border-radius: 16px;
+  padding: 12px 20px;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
   border: 1px solid transparent;
@@ -579,202 +583,58 @@ input[type="range"]:hover::-moz-range-thumb {
 }
 
 .error-message {
-  margin-top: 16px;
+  margin-top: 12px;
   min-height: 18px;
   font-size: 0.85rem;
   color: var(--color-danger);
 }
 
-.vault-panel {
-  display: flex;
-  flex-direction: column;
-  gap: 26px;
-}
-
-.vault-highlights {
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.vault-highlights li {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 16px;
-  border-radius: 16px;
-  background: rgba(30, 41, 59, 0.45);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  color: var(--color-text-muted);
-  font-size: 0.9rem;
-}
-
-.vault-highlights i {
-  color: var(--color-accent);
-}
-
-.vault-wireframe {
-  border-radius: 20px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(15, 23, 42, 0.55);
-  padding: 20px 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.vault-wireframe-header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 120px 90px;
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-text-muted);
-  opacity: 0.8;
-}
-
-.vault-item {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 120px 90px;
-  align-items: center;
-  gap: 12px;
-  padding: 12px 0;
-  border-top: 1px solid rgba(148, 163, 184, 0.14);
-}
-
-.vault-item:first-of-type {
-  border-top: none;
-}
-
-.vault-service {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.vault-service i {
-  width: 32px;
-  height: 32px;
-  border-radius: 10px;
-  display: grid;
-  place-items: center;
-  background: rgba(56, 189, 248, 0.16);
-  color: var(--color-accent);
-}
-
-.vault-service .title {
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.vault-service .meta {
-  display: block;
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
-}
-
-.vault-updated {
-  font-size: 0.8rem;
-  color: var(--color-text-muted);
-}
-
-.vault-strength {
-  font-size: 0.75rem;
-  font-weight: 600;
-  padding: 6px 12px;
-  border-radius: 999px;
-  text-align: center;
-}
-
-.vault-strength.strong {
-  background: rgba(34, 197, 94, 0.18);
-  color: var(--color-success);
-}
-
-.vault-strength.medium {
-  background: rgba(249, 115, 22, 0.18);
-  color: var(--color-warning);
-}
-
-.vault-strength.weak {
-  background: rgba(239, 68, 68, 0.18);
-  color: var(--color-danger);
-}
-
-.vault-empty {
-  margin-top: auto;
-  text-align: center;
-  border-radius: 22px;
-  border: 1px dashed rgba(148, 163, 184, 0.3);
-  background: rgba(15, 23, 42, 0.5);
-  padding: 28px 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  color: var(--color-text-muted);
-}
-
-.vault-empty i {
-  font-size: 2rem;
-  color: var(--color-accent);
-}
-
-.vault-empty h3 {
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-
-.vault-empty p {
-  font-size: 0.9rem;
-  line-height: 1.5;
-}
-
 @media (max-width: 1080px) {
   body {
-    padding: 24px;
+    justify-content: flex-start;
   }
 
-  .app-main {
-    grid-template-columns: 1fr;
-  }
 }
 
 @media (max-width: 720px) {
   body {
-    padding: 18px;
+    align-items: stretch;
+  }
+
+  .app-container {
+    width: 100%;
+    gap: 18px;
   }
 
   .app-header {
     flex-direction: column;
     align-items: flex-start;
-    gap: 16px;
+    gap: 14px;
   }
 
   .panel {
-    padding: 24px;
-  }
-
-  .toggle-grid {
-    grid-template-columns: 1fr;
+    padding: 20px;
   }
 
   .strength-text {
     min-width: auto;
   }
 
+  .primary-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .primary-controls #generateButton {
+    width: 100%;
+  }
+
   .copy-message {
     top: auto;
-    bottom: -36px;
+    bottom: -34px;
   }
 }
 
 @media (max-width: 520px) {
-  body {
-    padding: 16px;
-  }
-
   .app-container {
     gap: 20px;
   }
@@ -784,13 +644,14 @@ input[type="range"]:hover::-moz-range-thumb {
   }
 
   .brand-mark {
-    width: 44px;
-    height: 44px;
+    width: 40px;
+    height: 40px;
   }
 
   .password-display-container {
     flex-direction: column;
     align-items: stretch;
+    gap: 12px;
   }
 
   #copyButton {
@@ -807,7 +668,7 @@ input[type="range"]:hover::-moz-range-thumb {
     transform: translate(50%, 0);
   }
 
-  .action-row {
-    flex-direction: column;
+  .primary-controls #generateButton {
+    min-width: 0;
   }
 }


### PR DESCRIPTION
## Summary
- simplify the generator markup into a single focused panel with inline length controls, compact option groups, and stronger defaults enabled out of the box
- retune the stylesheet for the streamlined layout with tighter spacing, checkbox styling, and updated responsive behavior across breakpoints

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce05931b64832bb14123c54281e842